### PR TITLE
Fix historical data cache in marketDataService

### DIFF
--- a/src/lib/marketDataUtils.ts
+++ b/src/lib/marketDataUtils.ts
@@ -17,7 +17,8 @@ export interface StockData {
   volume: string;
   volatility?: number;  // Volatility factor (0-1)
   sector?: string;
-  historical?: MarketDataPoint[];
+  // Historical price data keyed by timeframe
+  historical?: Record<string, MarketDataPoint[]>;
 }
 
 export interface MarketIndex {

--- a/src/services/marketDataService.ts
+++ b/src/services/marketDataService.ts
@@ -366,9 +366,14 @@ export function getStockChartData(
     return [];
   }
   
-  // If we already have historical data cached, return it
-  if (stock.historical) {
-    return stock.historical;
+  // Initialize cache object if needed
+  if (!stock.historical) {
+    stock.historical = {};
+  }
+
+  // If data for this timeframe is cached, return it
+  if (stock.historical[timeframe]) {
+    return stock.historical[timeframe];
   }
   
   // Otherwise generate new historical data
@@ -382,9 +387,9 @@ export function getStockChartData(
     case "ALL": days = 1825; break; // 5 years
   }
   
-  // Generate and cache the data
+  // Generate and cache the data for this timeframe
   const data = generateHistoricalData(stock.price, days, stock.volatility || 0.7, timeframe);
-  stock.historical = data;
+  stock.historical[timeframe] = data;
   
   return data;
 }


### PR DESCRIPTION
## Summary
- cache historical price data per timeframe instead of a single dataset
- update `StockData` interface to use a map keyed by timeframe

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: npm attempted to access network)*

------
https://chatgpt.com/codex/tasks/task_e_685afaef7ea0832cac62b6cc7345936d